### PR TITLE
Start

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'figaro'
 group :development, :test do
   gem 'byebug'
   gem 'rspec-rails'
+  gem 'pry'
 end
 
 group :development do
@@ -27,4 +28,3 @@ group :test do
   gem 'webmock'
   gem 'capybara'
 end
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (>= 2.0, < 4.0)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -106,6 +107,9 @@ GEM
     nio4r (2.2.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     public_suffix (3.0.1)
     rack (2.0.4)
     rack-test (0.8.2)
@@ -215,6 +219,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   listen
+  pry
   rails (= 5.1.4)
   rspec-rails
   sass-rails (~> 5.0.6)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -4,7 +4,6 @@ class SearchController < ApplicationController
     @stations = StationService.new(zipcode).stations
   end
 
-
   private
 
     def zipcode

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -4,7 +4,11 @@ class SearchController < ApplicationController
     connection = Faraday.get("https://developer.nrel.gov/api/alt-fuel-stations/v1.json?zip=#{zipcode}&radius=6&fuel_type=LPG,ELEC&limit=10&api_key=#{ENV["NREL_API_KEY"]}&format=JSON")
     response = JSON.parse(connection.body, symbolize_names: true)
 
-    binding.pry
+    stations = response[:fuel_stations]
+    @stations = stations.map do |station|
+      Station.new(station)
+    end
+
   end
 
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,0 +1,14 @@
+class SearchController < ApplicationController
+
+  def index
+    binding.pry
+  end
+
+
+  private
+
+    def zipcode
+      params.permit("zipcode")["zipcode"]
+    end
+
+end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,6 +1,9 @@
 class SearchController < ApplicationController
 
   def index
+    connection = Faraday.get("https://developer.nrel.gov/api/alt-fuel-stations/v1.json?zip=#{zipcode}&radius=6&fuel_type=LPG,ELEC&limit=10&api_key=#{ENV["NREL_API_KEY"]}&format=JSON")
+    response = JSON.parse(connection.body, symbolize_names: true)
+
     binding.pry
   end
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,14 +1,7 @@
 class SearchController < ApplicationController
 
   def index
-    connection = Faraday.get("https://developer.nrel.gov/api/alt-fuel-stations/v1.json?zip=#{zipcode}&radius=6&fuel_type=LPG,ELEC&limit=10&api_key=#{ENV["NREL_API_KEY"]}&format=JSON")
-    response = JSON.parse(connection.body, symbolize_names: true)
-
-    stations = response[:fuel_stations]
-    @stations = stations.map do |station|
-      Station.new(station)
-    end
-
+    @stations = StationService.new(zipcode).stations
   end
 
 

--- a/app/services/station.rb
+++ b/app/services/station.rb
@@ -1,12 +1,17 @@
 class Station
 
-  attr_reader :name, :address, :fuel_type, :access_times
-  
+  attr_reader :name,
+              :address,
+              :fuel_type,
+              :access_times,
+              :distance
+
   def initialize(attributes)
     @name = attributes[:station_name]
     @address = attributes[:street_address]
     @fuel_type = attributes[:fuel_type_code]
     @access_times = attributes[:access_days_time]
+    @distance = 6
   end
 
 

--- a/app/services/station.rb
+++ b/app/services/station.rb
@@ -11,7 +11,7 @@ class Station
     @address = attributes[:street_address]
     @fuel_type = attributes[:fuel_type_code]
     @access_times = attributes[:access_days_time]
-    @distance = 6
+    @distance = attributes[:distance]
   end
 
 

--- a/app/services/station.rb
+++ b/app/services/station.rb
@@ -1,5 +1,4 @@
 class Station
-
   attr_reader :name,
               :address,
               :fuel_type,
@@ -13,6 +12,4 @@ class Station
     @access_times = attributes[:access_days_time]
     @distance = attributes[:distance]
   end
-
-
 end

--- a/app/services/station.rb
+++ b/app/services/station.rb
@@ -1,0 +1,13 @@
+class Station
+
+  attr_reader :name, :address, :fuel_type, :access_times
+  
+  def initialize(attributes)
+    @name = attributes[:station_name]
+    @address = attributes[:street_address]
+    @fuel_type = attributes[:fuel_type_code]
+    @access_times = attributes[:access_days_time]
+  end
+
+
+end

--- a/app/services/station_service.rb
+++ b/app/services/station_service.rb
@@ -1,0 +1,22 @@
+class StationService
+  attr_reader :zipcode
+
+  def initialize(zipcode)
+    @zipcode = zipcode
+  end
+
+  def stations
+    connection[:fuel_stations].map do |station|
+      Station.new(station)
+    end
+  end
+
+  def connection
+    get_json(Faraday.get("https://developer.nrel.gov/api/alt-fuel-stations/v1.json?zip=#{zipcode}&radius=6&fuel_type=LPG,ELEC&limit=10&api_key=#{ENV["NREL_API_KEY"]}&format=JSON").body)
+  end
+
+  def get_json(url)
+    JSON.parse(url, symbolize_names: true)
+  end
+
+end

--- a/app/services/station_service.rb
+++ b/app/services/station_service.rb
@@ -11,12 +11,14 @@ class StationService
     end
   end
 
-  def connection
-    get_json(Faraday.get("https://developer.nrel.gov/api/alt-fuel-stations/v1.json?zip=#{zipcode}&radius=6&fuel_type=LPG,ELEC&limit=10&api_key=#{ENV["NREL_API_KEY"]}&format=JSON").body)
-  end
+  private
 
-  def get_json(url)
-    JSON.parse(url, symbolize_names: true)
-  end
+    def connection
+      get_json(Faraday.get("https://developer.nrel.gov/api/alt-fuel-stations/v1.json?zip=#{zipcode}&radius=6&fuel_type=LPG,ELEC&limit=10&api_key=#{ENV["NREL_API_KEY"]}&format=JSON").body)
+    end
+
+    def get_json(url)
+      JSON.parse(url, symbolize_names: true)
+    end
 
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,7 @@
         <ul class="nav navbar-nav">
           <%= form_tag :search, method: :get, class: "form-inline" do %>
             <div class="form-group search-field">
-              <%= text_field_tag :q, "Search by zip...", class: "form-control" %>
+              <%= text_field_tag :zipcode, "Search by zip...", class: "form-control" %>
               <%= submit_tag "Locate", class: "btn btn-primary" %>
             </div>
           <% end %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,4 +1,5 @@
-<h3> <%= @stations.count %> closest stations</h3>
+<h3><%= @stations.count %> closest stations</h3>
+<h4>Fuel types: Electric(ELEC) and Propane(LPG)</h4>
 
 <% @stations.each do |station| %>
   <div class="station">

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,11 +1,11 @@
 <h3> <%= @stations.count %> closest stations</h3>
 
-<%= @stations.each do |station| %>
+<% @stations.each do |station| %>
   <div class="station">
     <li class="name"> <%=station.name  %> </li>
     <li class="address"> <%=station.address  %> </li>
     <li class="fuel_type"> <%=station.fuel_type  %> </li>
-    <li class="distance"> <%=station.distance  %> </li>
     <li class="access_times"> <%=station.access_times  %> </li>
+    <li class="distance"> <%=station.distance  %> </li>
   </div>
 <% end %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,7 +1,11 @@
+<h3> <%= @stations.count %> closest stations</h3>
+
 <%= @stations.each do |station| %>
-  <li class="name"> <%=station.name  %> </li>
-  <li class="address"> <%=station.address  %> </li>
-  <li class="fuel_type"> <%=station.fuel_type  %> </li>
-  <li class="distance"> <%=station.distance  %> </li>
-  <li class="access_times"> <%=station.access_times  %> </li>
+  <div class="station">
+    <li class="name"> <%=station.name  %> </li>
+    <li class="address"> <%=station.address  %> </li>
+    <li class="fuel_type"> <%=station.fuel_type  %> </li>
+    <li class="distance"> <%=station.distance  %> </li>
+    <li class="access_times"> <%=station.access_times  %> </li>
+  </div>
 <% end %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,0 +1,7 @@
+<%= @stations.each do |station| %>
+  <li class="name"> <%=station.name  %> </li>
+  <li class="address"> <%=station.address  %> </li>
+  <li class="fuel_type"> <%=station.fuel_type  %> </li>
+  <li class="distance"> <%=station.distance  %> </li>
+  <li class="access_times"> <%=station.access_times  %> </li>
+<% end %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,0 +1,1 @@
+<h1>Welcome to NREL alt fuel station search</h1>

--- a/spec/features/user_can_search_for_stations_spec.rb
+++ b/spec/features/user_can_search_for_stations_spec.rb
@@ -5,7 +5,7 @@ describe "As a user" do
     context "And enter a zipcode (80203) into the search bar and click Locate" do
       it "will return a list of the 10 closest stations" do
         visit "/"
-        fill_in "search", with: 80203
+        fill_in "zipcode", with: 80203
         click_on "Locate"
 
         expect(current_path).to eq "/search"
@@ -14,7 +14,7 @@ describe "As a user" do
         expect(page).to have_content "Propane"
         expect(page).to have_css(".station", count: 10)
 
-        within(first(".station")).first do
+        within(first(".station")) do
           expect(page).to have_css(".name")
           expect(page).to have_css(".address")
           expect(page).to have_css(".fuel_type")

--- a/spec/features/user_can_search_for_stations_spec.rb
+++ b/spec/features/user_can_search_for_stations_spec.rb
@@ -10,8 +10,6 @@ describe "As a user" do
 
         expect(current_path).to eq "/search"
         expect(page).to have_content "1 closest stations"
-        # expect(page).to have_content "Electric"
-        # expect(page).to have_content "Propane"
         expect(page).to have_css(".station", count: 1)
 
         within(first(".station")) do

--- a/spec/features/user_can_search_for_stations_spec.rb
+++ b/spec/features/user_can_search_for_stations_spec.rb
@@ -9,10 +9,10 @@ describe "As a user" do
         click_on "Locate"
 
         expect(current_path).to eq "/search"
-        expect(page).to have_content "10 closest stations"
-        expect(page).to have_content "Electric"
-        expect(page).to have_content "Propane"
-        expect(page).to have_css(".station", count: 10)
+        expect(page).to have_content "1 closest stations"
+        # expect(page).to have_content "Electric"
+        # expect(page).to have_content "Propane"
+        expect(page).to have_css(".station", count: 1)
 
         within(first(".station")) do
           expect(page).to have_css(".name")

--- a/spec/features/user_can_search_for_stations_spec.rb
+++ b/spec/features/user_can_search_for_stations_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe "As a user" do
+  context "When I visit the root path" do
+    context "And enter a zipcode (80203) into the search bar and click Locate" do
+      it "will return a list of the 10 closest stations" do
+        visit "/"
+        fill_in "search", with: 80203
+        click_on "Locate"
+
+        expect(current_path).to eq "/search"
+        expect(page).to have_content "10 closest stations"
+        expect(page).to have_content "Electric"
+        expect(page).to have_content "Propane"
+        expect(page).to have_css(".station", count: 10)
+
+        within(first(".station")).first do
+          expect(page).to have_css(".name")
+          expect(page).to have_css(".address")
+          expect(page).to have_css(".fuel_type")
+          expect(page).to have_css(".distance")
+          expect(page).to have_css(".access_times")
+        end
+      end
+    end
+  end
+end
+
+# As a user
+# When I visit "/"
+# And I fill in the search form with 80203
+# And I click "Locate"
+# Then I should be on page "/search" with parameters visible in the url
+# Then I should see a list of the 10 closest stations within 6 miles sorted by distance
+# And the stations should be limited to Electric and Propane
+# And for each of the stations I should see Name, Address, Fuel Types, Distance, and Access Times

--- a/spec/services/station_service_spec.rb
+++ b/spec/services/station_service_spec.rb
@@ -1,5 +1,17 @@
 require 'rails_helper'
 
 describe StationService do
-  
+  let(:station_service) {StationService.new("80203")}
+
+  it "exists" do
+    expect(station_service).to be_a StationService
+  end
+
+  context "Instance Methods" do
+    it "#stations returns all stations" do
+      expect(station_service.stations).to be_a Array
+      expect(station_service.stations.first).to be_a Station
+      expect(station_service.stations.first.name).to be_a String
+    end
+  end
 end

--- a/spec/services/station_service_spec.rb
+++ b/spec/services/station_service_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+describe StationService do
+  
+end

--- a/spec/services/station_spec.rb
+++ b/spec/services/station_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 describe Station do
-  let(:station) {Station.new({name: "station1",
-                              address: "here",
-                              fuel_type: "electric",
-                              access_times: "everyday",
+  let(:station) {Station.new({station_name: "station1",
+                              street_address: "here",
+                              fuel_type_code: "electric",
+                              access_days_time: "everyday",
                               distance: 5
                   })}
 

--- a/spec/services/station_spec.rb
+++ b/spec/services/station_spec.rb
@@ -12,5 +12,11 @@ describe Station do
     expect(station).to be_a Station
   end
 
-  
+  it "has desired attributes" do
+    expect(station.name).to eq "station1"
+    expect(station.address).to eq "here"
+    expect(station.fuel_type).to eq "electric"
+    expect(station.access_times).to eq "everyday"
+    expect(station.distance).to eq 5
+  end
 end

--- a/spec/services/station_spec.rb
+++ b/spec/services/station_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe Station do
+  let(:station) {Station.new({name: "station1",
+                              address: "here",
+                              fuel_type: "electric",
+                              access_times: "everyday",
+                              distance: 5
+                  })}
+
+  it "exists" do
+    expect(station).to be_a Station
+  end
+
+  
+end


### PR DESCRIPTION
Finished User Story except for distance attribute for each station.
-distance attribute not appearing even when entering zip and location params
-not sure, as the NREL docs state there should be a distance attribute returned under the fuel station record information.

